### PR TITLE
resolve #13 ログフォーマットにタイムゾーンを追加、ログレベルを表す項目の物理名を変更

### DIFF
--- a/src/PhpJsonLogger/JsonFormatter.php
+++ b/src/PhpJsonLogger/JsonFormatter.php
@@ -26,6 +26,7 @@ class JsonFormatter extends BaseJsonFormatter
             'remote_ip_address' => $this->extractIp(),
             'user_agent'        => $this->extractUserAgent(),
             'datetime'          => $record['datetime']->format('Y-m-d H:i:s'),
+            'timezone'          => $record['datetime']->getTimezone()->getName(),
         ];
 
         unset($formattedRecord['context']['file']);

--- a/src/PhpJsonLogger/JsonFormatter.php
+++ b/src/PhpJsonLogger/JsonFormatter.php
@@ -17,12 +17,12 @@ class JsonFormatter extends BaseJsonFormatter
     public function format(array $record)
     {
         $formattedRecord = [
+            'log_level'         => $record['level_name'],
             'message'           => $record['message'],
             'trace_id'          => $record['message'],
             'file'              => $record['context']['file'],
             'line'              => $record['context']['line'],
             'context'           => $record['context'],
-            'level_name'        => $record['level_name'],
             'remote_ip_address' => $this->extractIp(),
             'user_agent'        => $this->extractUserAgent(),
             'datetime'          => $record['datetime']->format('Y-m-d H:i:s'),


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/php-json-logger/issues/13

# やった事
- タイムゾーンの追加
- ログレベルを表す項目を `log_level` に変更し先頭に移動（先頭にログレベルがあったほうが見やすい）