### PR TITLE
resolve #8 info, error以外の全てのログレベルメソッドを実装

### DIFF
--- a/src/PhpJsonLogger/Logger.php
+++ b/src/PhpJsonLogger/Logger.php
@@ -72,6 +72,19 @@ class Logger
 
     /**
      * @param $message
+     * @param $context
+     */
+    public function debug($message, $context = [])
+    {
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $this->monologInstance->addDebug($message, $context);
+    }
+
+    /**
+     * @param $message
      * @param array $context
      */
     public function info($message, array $context = [])
@@ -81,6 +94,32 @@ class Logger
         $context['php_json_logger']['line'] = $trace[0]['line'];
 
         $this->monologInstance->addInfo($message, $context);
+    }
+
+    /**
+     * @param $message
+     * @param array $context
+     */
+    public function notice($message, array $context = [])
+    {
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $this->monologInstance->addNotice($message, $context);
+    }
+
+    /**
+     * @param $message
+     * @param array $context
+     */
+    public function warning($message, array $context = [])
+    {
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $this->monologInstance->addWarning($message, $context);
     }
 
     /**
@@ -121,6 +160,126 @@ class Logger
         $context['php_json_logger']['errors']['trace'] = $stackTrace;
 
         $this->monologInstance->addError(get_class($e), $context);
+    }
+
+    /**
+     * @param \Throwable $e
+     * @param array $context
+     */
+    public function critical(\Throwable $e, array $context = [])
+    {
+        $stackTrace = [];
+        $i = 0;
+        foreach ($e->getTrace() as $trace) {
+            $format = sprintf(
+                '#%s %s(%s): %s%s%s()',
+                $i,
+                $trace['file'],
+                $trace['line'],
+                $trace['class'],
+                $trace['type'],
+                $trace['function']
+            );
+
+            array_push(
+                $stackTrace,
+                $format
+            );
+
+            $i++;
+        }
+
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $context['php_json_logger']['errors']['message'] = $e->getMessage();
+        $context['php_json_logger']['errors']['code'] = $e->getCode();
+        $context['php_json_logger']['errors']['file'] = $e->getFile();
+        $context['php_json_logger']['errors']['line'] = $e->getLine();
+        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+
+        $this->monologInstance->addCritical(get_class($e), $context);
+    }
+
+    /**
+     * @param \Throwable $e
+     * @param array $context
+     */
+    public function alert(\Throwable $e, array $context = [])
+    {
+        $stackTrace = [];
+        $i = 0;
+        foreach ($e->getTrace() as $trace) {
+            $format = sprintf(
+                '#%s %s(%s): %s%s%s()',
+                $i,
+                $trace['file'],
+                $trace['line'],
+                $trace['class'],
+                $trace['type'],
+                $trace['function']
+            );
+
+            array_push(
+                $stackTrace,
+                $format
+            );
+
+            $i++;
+        }
+
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $context['php_json_logger']['errors']['message'] = $e->getMessage();
+        $context['php_json_logger']['errors']['code'] = $e->getCode();
+        $context['php_json_logger']['errors']['file'] = $e->getFile();
+        $context['php_json_logger']['errors']['line'] = $e->getLine();
+        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+
+        $this->monologInstance->addAlert(get_class($e), $context);
+    }
+
+    /**
+     * @param \Throwable $e
+     * @param array $context
+     */
+    public function emergency(\Throwable $e, array $context = [])
+    {
+        $stackTrace = [];
+        $i = 0;
+        foreach ($e->getTrace() as $trace) {
+            $format = sprintf(
+                '#%s %s(%s): %s%s%s()',
+                $i,
+                $trace['file'],
+                $trace['line'],
+                $trace['class'],
+                $trace['type'],
+                $trace['function']
+            );
+
+            array_push(
+                $stackTrace,
+                $format
+            );
+
+            $i++;
+        }
+
+        $trace = debug_backtrace();
+        $context['php_json_logger']['file'] = $trace[0]['file'];
+        $context['php_json_logger']['line'] = $trace[0]['line'];
+
+        $context['php_json_logger']['errors']['message'] = $e->getMessage();
+        $context['php_json_logger']['errors']['code'] = $e->getCode();
+        $context['php_json_logger']['errors']['file'] = $e->getFile();
+        $context['php_json_logger']['errors']['line'] = $e->getLine();
+        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+
+        $this->monologInstance->addEmergency(get_class($e), $context);
     }
 
     /**

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -314,4 +314,43 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame(500, $logger->getLogLevel());
     }
+
+    /**
+     * @test
+     */
+    public function outputDebugLog()
+    {
+        $context = [
+            'title' => 'Test',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $loggerBuilder->setLogLevel(LoggerBuilder::DEBUG);
+        $logger = $loggerBuilder->build();
+        $logger->debug('🐶', $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'DEBUG',
+            'message'           => '🐶',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 330,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -529,4 +529,52 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame($expectedLog, $resultArray);
     }
+
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function outputEmergencyLog()
+    {
+        $exception = new \ErrorException('TestCritical', 500);
+        $context = [
+            'name'  => 'keitakn',
+            'email' => 'dummy@email.com',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $logger = $loggerBuilder->build();
+        $logger->emergency($exception, $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'EMERGENCY',
+            'message'           => 'ErrorException',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 547,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+            'errors'            => [
+                'message' => 'TestCritical',
+                'code'    => 500,
+                'file'    => __FILE__,
+                'line'    => 539,
+                'trace'   => $resultArray['errors']['trace'],
+            ],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -433,4 +433,52 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame($expectedLog, $resultArray);
     }
+
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function outputCriticalLog()
+    {
+        $exception = new \ErrorException('TestCritical', 500);
+        $context = [
+            'name'  => 'keitakn',
+            'email' => 'dummy@email.com',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $logger = $loggerBuilder->build();
+        $logger->critical($exception, $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'CRITICAL',
+            'message'           => 'ErrorException',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 451,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+            'errors'            => [
+                'message' => 'TestCritical',
+                'code'    => 500,
+                'file'    => __FILE__,
+                'line'    => 443,
+                'trace'   => $resultArray['errors']['trace'],
+            ],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -393,4 +393,44 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame($expectedLog, $resultArray);
     }
+
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function outputWarningLog()
+    {
+        $context = [
+            'title' => 'Test',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $loggerBuilder->setLogLevel(LoggerBuilder::DEBUG);
+        $logger = $loggerBuilder->build();
+        $logger->warning('🐶', $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'WARNING',
+            'message'           => '🐶',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 410,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -481,4 +481,52 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame($expectedLog, $resultArray);
     }
+
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function outputAlertLog()
+    {
+        $exception = new \ErrorException('TestCritical', 500);
+        $context = [
+            'name'  => 'keitakn',
+            'email' => 'dummy@email.com',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $logger = $loggerBuilder->build();
+        $logger->alert($exception, $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'ALERT',
+            'message'           => 'ErrorException',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 499,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+            'errors'            => [
+                'message' => 'TestCritical',
+                'code'    => 500,
+                'file'    => __FILE__,
+                'line'    => 491,
+                'trace'   => $resultArray['errors']['trace'],
+            ],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -353,4 +353,44 @@ class LoggerTest extends TestCase
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame($expectedLog, $resultArray);
     }
+
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function outputNoticeLog()
+    {
+        $context = [
+            'title' => 'Test',
+        ];
+
+        $loggerBuilder = new LoggerBuilder();
+        $loggerBuilder->setLogLevel(LoggerBuilder::DEBUG);
+        $logger = $loggerBuilder->build();
+        $logger->notice('🐶', $context);
+
+        $resultJson = file_get_contents('/tmp/php-json-logger-' . date('Y-m-d') . '.log');
+        $resultArray = json_decode($resultJson, true);
+
+        echo "\n ---- Output Log Begin ---- \n";
+        echo json_encode($resultArray, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        echo "\n ---- Output Log End   ---- \n";
+
+        $expectedLog = [
+            'log_level'         => 'NOTICE',
+            'message'           => '🐶',
+            'trace_id'          => $logger->getTraceId(),
+            'file'              => __FILE__,
+            'line'              => 370,
+            'context'           => $context,
+            'remote_ip_address' => '127.0.0.1',
+            'user_agent'        => 'unknown',
+            'datetime'          => $resultArray['datetime'],
+            'timezone'          => 'Asia/Tokyo',
+            'process_time'      => $resultArray['process_time'],
+        ];
+
+        $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
+        $this->assertSame($expectedLog, $resultArray);
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/php-json-logger/issues/8

# やった事
info, error以外の全てのログレベルメソッドを実装。

コードが肥大化してきているので、そろそろリファクタリングを実施する必要がある。