### PR TITLE
resolve #23 Exceptionクラスのトレースに特定のキーが存在しなくても動作するように改修

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## 0.0.2 - 2018-05-31
+Bug fix
+- https://github.com/nekonomokochan/php-json-logger/issues/23
+
 ## 0.0.1 - 2018-05-24
 Initial release

--- a/src/PhpJsonLogger/Logger.php
+++ b/src/PhpJsonLogger/Logger.php
@@ -128,27 +128,7 @@ class Logger
      */
     public function error(\Throwable $e, array $context = [])
     {
-        $stackTrace = [];
-        $i = 0;
-        foreach ($e->getTrace() as $trace) {
-            $format = sprintf(
-                '#%s %s(%s): %s%s%s()',
-                $i,
-                $trace['file'],
-                $trace['line'],
-                $trace['class'],
-                $trace['type'],
-                $trace['function']
-            );
-
-            array_push(
-                $stackTrace,
-                $format
-            );
-
-            $i++;
-        }
-
+        $formattedTrace = $this->formatStackTrace($e);
         $trace = debug_backtrace();
         $context['php_json_logger']['file'] = $trace[0]['file'];
         $context['php_json_logger']['line'] = $trace[0]['line'];
@@ -157,7 +137,7 @@ class Logger
         $context['php_json_logger']['errors']['code'] = $e->getCode();
         $context['php_json_logger']['errors']['file'] = $e->getFile();
         $context['php_json_logger']['errors']['line'] = $e->getLine();
-        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+        $context['php_json_logger']['errors']['trace'] = $formattedTrace;
 
         $this->monologInstance->addError(get_class($e), $context);
     }
@@ -168,27 +148,7 @@ class Logger
      */
     public function critical(\Throwable $e, array $context = [])
     {
-        $stackTrace = [];
-        $i = 0;
-        foreach ($e->getTrace() as $trace) {
-            $format = sprintf(
-                '#%s %s(%s): %s%s%s()',
-                $i,
-                $trace['file'],
-                $trace['line'],
-                $trace['class'],
-                $trace['type'],
-                $trace['function']
-            );
-
-            array_push(
-                $stackTrace,
-                $format
-            );
-
-            $i++;
-        }
-
+        $formattedTrace = $this->formatStackTrace($e);
         $trace = debug_backtrace();
         $context['php_json_logger']['file'] = $trace[0]['file'];
         $context['php_json_logger']['line'] = $trace[0]['line'];
@@ -197,7 +157,7 @@ class Logger
         $context['php_json_logger']['errors']['code'] = $e->getCode();
         $context['php_json_logger']['errors']['file'] = $e->getFile();
         $context['php_json_logger']['errors']['line'] = $e->getLine();
-        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+        $context['php_json_logger']['errors']['trace'] = $formattedTrace;
 
         $this->monologInstance->addCritical(get_class($e), $context);
     }
@@ -208,27 +168,7 @@ class Logger
      */
     public function alert(\Throwable $e, array $context = [])
     {
-        $stackTrace = [];
-        $i = 0;
-        foreach ($e->getTrace() as $trace) {
-            $format = sprintf(
-                '#%s %s(%s): %s%s%s()',
-                $i,
-                $trace['file'],
-                $trace['line'],
-                $trace['class'],
-                $trace['type'],
-                $trace['function']
-            );
-
-            array_push(
-                $stackTrace,
-                $format
-            );
-
-            $i++;
-        }
-
+        $formattedTrace = $this->formatStackTrace($e);
         $trace = debug_backtrace();
         $context['php_json_logger']['file'] = $trace[0]['file'];
         $context['php_json_logger']['line'] = $trace[0]['line'];
@@ -237,7 +177,7 @@ class Logger
         $context['php_json_logger']['errors']['code'] = $e->getCode();
         $context['php_json_logger']['errors']['file'] = $e->getFile();
         $context['php_json_logger']['errors']['line'] = $e->getLine();
-        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+        $context['php_json_logger']['errors']['trace'] = $formattedTrace;
 
         $this->monologInstance->addAlert(get_class($e), $context);
     }
@@ -248,27 +188,7 @@ class Logger
      */
     public function emergency(\Throwable $e, array $context = [])
     {
-        $stackTrace = [];
-        $i = 0;
-        foreach ($e->getTrace() as $trace) {
-            $format = sprintf(
-                '#%s %s(%s): %s%s%s()',
-                $i,
-                $trace['file'],
-                $trace['line'],
-                $trace['class'],
-                $trace['type'],
-                $trace['function']
-            );
-
-            array_push(
-                $stackTrace,
-                $format
-            );
-
-            $i++;
-        }
-
+        $formattedTrace = $this->formatStackTrace($e);
         $trace = debug_backtrace();
         $context['php_json_logger']['file'] = $trace[0]['file'];
         $context['php_json_logger']['line'] = $trace[0]['line'];
@@ -277,7 +197,7 @@ class Logger
         $context['php_json_logger']['errors']['code'] = $e->getCode();
         $context['php_json_logger']['errors']['file'] = $e->getFile();
         $context['php_json_logger']['errors']['line'] = $e->getLine();
-        $context['php_json_logger']['errors']['trace'] = $stackTrace;
+        $context['php_json_logger']['errors']['trace'] = $formattedTrace;
 
         $this->monologInstance->addEmergency(get_class($e), $context);
     }
@@ -344,5 +264,35 @@ class Logger
             $fileName,
             date('Y-m-d')
         );
+    }
+
+    /**
+     * @param \Throwable $e
+     * @return array
+     */
+    private function formatStackTrace(\Throwable $e): array
+    {
+        $stackTrace = [];
+        $i = 0;
+        foreach ($e->getTrace() as $trace) {
+            $format = sprintf(
+                '#%s %s(%s): %s%s%s()',
+                $i,
+                $trace['file'] ?? '',
+                $trace['line'] ?? '',
+                $trace['class'] ?? '',
+                $trace['type'] ?? '',
+                $trace['function'] ?? ''
+            );
+
+            array_push(
+                $stackTrace,
+                $format
+            );
+
+            $i++;
+        }
+
+        return $stackTrace;
     }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/php-json-logger/issues/23

# やった事
- 特定のキーが存在しない場合は空文字を設定するように改修
- Exceptionのトレース生成処理を別メソッドに分離