### PR TITLE
resolve #29 RotatingFileHandlerを利用するように改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you want to change the output filepath, please set the output filepath to the
 <?php
 use Nekonomokochan\PhpJsonLogger\LoggerBuilder;
 
-$fileName = '/tmp/test-php-json-logger';
+$fileName = '/tmp/test-php-json-logger.log';
 
 $context = [
     'cat'    => '🐱',

--- a/src/PhpJsonLogger/LoggerBuilder.php
+++ b/src/PhpJsonLogger/LoggerBuilder.php
@@ -59,6 +59,16 @@ class LoggerBuilder
     const EMERGENCY = 600;
 
     /**
+     * @see \Monolog\Processor\IntrospectionProcessor::$skipClassesPartials
+     */
+    const DEFAULT_SKIP_CLASSES_PARTIALS = ['Nekonomokochan\\PhpJsonLogger\\'];
+
+    /**
+     * @see @see \Monolog\Processor\IntrospectionProcessor::$skipStackFramesCount
+     */
+    const DEFAULT_SKIP_STACK_FRAMES_COUNT = 0;
+
+    /**
      * @var string
      */
     private $traceId;
@@ -77,13 +87,13 @@ class LoggerBuilder
      * @var array
      * @see \Monolog\Processor\IntrospectionProcessor::$skipClassesPartials
      */
-    private $skipClassesPartials = ['Nekonomokochan\\PhpJsonLogger\\'];
+    private $skipClassesPartials;
 
     /**
      * @var int
      * @see \Monolog\Processor\IntrospectionProcessor::$skipStackFramesCount
      */
-    private $skipStackFramesCount = 0;
+    private $skipStackFramesCount;
 
     /**
      * LoggerBuilder constructor.
@@ -95,6 +105,8 @@ class LoggerBuilder
         $this->traceId = $traceId;
         $this->logLevel = self::INFO;
         $this->fileName = '/tmp/php-json-logger.log';
+        $this->setSkipClassesPartials(self::DEFAULT_SKIP_CLASSES_PARTIALS);
+        $this->setSkipStackFramesCount(self::DEFAULT_SKIP_STACK_FRAMES_COUNT);
     }
 
     /**

--- a/src/PhpJsonLogger/LoggerBuilder.php
+++ b/src/PhpJsonLogger/LoggerBuilder.php
@@ -92,7 +92,7 @@ class LoggerBuilder
     {
         $this->traceId = $traceId;
         $this->logLevel = self::INFO;
-        $this->fileName = '/tmp/php-json-logger';
+        $this->fileName = '/tmp/php-json-logger.log';
     }
 
     /**

--- a/src/PhpJsonLogger/LoggerBuilder.php
+++ b/src/PhpJsonLogger/LoggerBuilder.php
@@ -75,11 +75,13 @@ class LoggerBuilder
 
     /**
      * @var array
+     * @see \Monolog\Processor\IntrospectionProcessor::$skipClassesPartials
      */
     private $skipClassesPartials = ['Nekonomokochan\\PhpJsonLogger\\'];
 
     /**
      * @var int
+     * @see \Monolog\Processor\IntrospectionProcessor::$skipStackFramesCount
      */
     private $skipStackFramesCount = 0;
 

--- a/src/PhpJsonLogger/LoggerBuilder.php
+++ b/src/PhpJsonLogger/LoggerBuilder.php
@@ -87,7 +87,7 @@ class LoggerBuilder
      * @var array
      * @see \Monolog\Processor\IntrospectionProcessor::$skipClassesPartials
      */
-    private $skipClassesPartials;
+    private $skipClassesPartials = [];
 
     /**
      * @var int

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -245,8 +245,8 @@ class LoggerTest extends TestCase
      */
     public function setLogFileName()
     {
-        $fileName = '/tmp/test-php-json-logger';
-        $outputLogFile = $fileName . '-' . date('Y-m-d') . '.log';
+        $fileName = '/tmp/test-php-json-logger.log';
+        $outputLogFile = '/tmp/test-php-json-logger-' . date('Y-m-d') . '.log';
         if (file_exists($outputLogFile)) {
             unlink($outputLogFile);
         }
@@ -285,7 +285,7 @@ class LoggerTest extends TestCase
 
         $this->assertSame('PhpJsonLogger', $logger->getMonologInstance()->getName());
         $this->assertSame(
-            '/tmp/test-php-json-logger-' . date('Y-m-d') . '.log',
+            $fileName,
             $logger->getLogFileName()
         );
         $this->assertSame($expectedLog, $resultArray);


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/php-json-logger/issues/29

# やった事
- ログローテートを行うために `RotatingFileHandler` を利用するように変更
- 上記対応により不要になったメソッドを削除
- ファイル名の設定方法が変わったのでREADMEを変更