### PR TITLE
Added server environment variable to Slack notification contents

### DIFF
--- a/src/PhpJsonLogger/Logger.php
+++ b/src/PhpJsonLogger/Logger.php
@@ -111,6 +111,8 @@ class Logger
             );
 
             $webProcessor = new WebProcessor();
+            $webProcessor->addExtraField('server_ip_address', 'SERVER_ADDR');
+            $webProcessor->addExtraField('user_agent', 'HTTP_USER_AGENT');
             array_push($processors, $webProcessor);
         }
 

--- a/src/PhpJsonLogger/Logger.php
+++ b/src/PhpJsonLogger/Logger.php
@@ -110,12 +110,6 @@ class Logger
                 $slack
             );
 
-            $_SERVER['REQUEST_URI'] = '/test/hoge';
-            $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-            $_SERVER['REQUEST_METHOD'] = 'GET';
-            $_SERVER['SERVER_NAME'] = 'aaa';
-            $_SERVER['HTTP_REFERER'] = 'qqqqqq';
-
             $webProcessor = new WebProcessor();
             array_push($processors, $webProcessor);
         }

--- a/tests/Logger/SlackNotificationTest.php
+++ b/tests/Logger/SlackNotificationTest.php
@@ -53,11 +53,23 @@ class SlackNotificationTest extends TestCase
         $slackHandlerBuilder = new SlackHandlerBuilder($slackToken, $slackChannel);
         $slackHandlerBuilder->setLevel(LoggerBuilder::CRITICAL);
 
+        $_SERVER['REQUEST_URI'] = '/tests/notifications';
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.10';
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['SERVER_NAME'] = 'cat-moko.localhost';
+        $_SERVER['HTTP_REFERER'] = 'https://github.com/nekonomokochan/php-json-logger/issues/50';
+
         $loggerBuilder = new LoggerBuilder();
         $loggerBuilder->setFileName($this->outputFileBaseName);
         $loggerBuilder->setSlackHandler($slackHandlerBuilder->build());
         $logger = $loggerBuilder->build();
         $logger->critical($exception, $context);
+
+        unset($_SERVER['REQUEST_URI']);
+        unset($_SERVER['REMOTE_ADDR']);
+        unset($_SERVER['REQUEST_METHOD']);
+        unset($_SERVER['SERVER_NAME']);
+        unset($_SERVER['HTTP_REFERER']);
 
         $resultJson = file_get_contents($this->outputFileName);
         $resultArray = json_decode($resultJson, true);
@@ -72,7 +84,7 @@ class SlackNotificationTest extends TestCase
             'channel'           => 'PhpJsonLogger',
             'trace_id'          => $logger->getTraceId(),
             'file'              => __FILE__,
-            'line'              => 60,
+            'line'              => 66,
             'context'           => $context,
             'remote_ip_address' => '127.0.0.1',
             'user_agent'        => 'unknown',

--- a/tests/Logger/SlackNotificationTest.php
+++ b/tests/Logger/SlackNotificationTest.php
@@ -58,6 +58,8 @@ class SlackNotificationTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['SERVER_NAME'] = 'cat-moko.localhost';
         $_SERVER['HTTP_REFERER'] = 'https://github.com/nekonomokochan/php-json-logger/issues/50';
+        $_SERVER['SERVER_ADDR'] = '10.0.0.11';
+        $_SERVER['HTTP_USER_AGENT'] = 'Chrome';
 
         $loggerBuilder = new LoggerBuilder();
         $loggerBuilder->setFileName($this->outputFileBaseName);
@@ -70,6 +72,8 @@ class SlackNotificationTest extends TestCase
         unset($_SERVER['REQUEST_METHOD']);
         unset($_SERVER['SERVER_NAME']);
         unset($_SERVER['HTTP_REFERER']);
+        unset($_SERVER['SERVER_ADDR']);
+        unset($_SERVER['HTTP_USER_AGENT']);
 
         $resultJson = file_get_contents($this->outputFileName);
         $resultArray = json_decode($resultJson, true);
@@ -84,10 +88,10 @@ class SlackNotificationTest extends TestCase
             'channel'           => 'PhpJsonLogger',
             'trace_id'          => $logger->getTraceId(),
             'file'              => __FILE__,
-            'line'              => 66,
+            'line'              => 68,
             'context'           => $context,
-            'remote_ip_address' => '127.0.0.1',
-            'user_agent'        => 'unknown',
+            'remote_ip_address' => '192.168.10.10',
+            'user_agent'        => 'Chrome',
             'datetime'          => $resultArray['datetime'],
             'timezone'          => date_default_timezone_get(),
             'process_time'      => $resultArray['process_time'],


### PR DESCRIPTION
# Summary
The following content has been added to Slack notification content.

- REQUEST_URI
- REMOTE_ADDR
- REQUEST_METHOD
- SERVER_NAME
- HTTP_REFERER
- SERVER_ADDR
- HTTP_USER_AGENT


# IssueURL
https://github.com/nekonomokochan/php-json-logger/issues/50